### PR TITLE
Fix issue where harvest time entries were being double-logged

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "ts-node ./index.ts",
     "tc": "tsc --noEmit",
-    "prettier-write": "prettier --config ./.prettierrc **/*.ts --write",
-    "prettier-check": "prettier --check --config ./.prettierrc **/*.ts",
+    "prettier:write": "prettier --config ./.prettierrc **/*.ts --write",
+    "prettier:check": "prettier --check --config ./.prettierrc **/*.ts",
     "lint": "npm run tc && npm run prettier-check"
   },
   "author": "jrdmacfarlane@gmail.com",

--- a/types.ts
+++ b/types.ts
@@ -54,6 +54,7 @@ export type EmojiContent = {
     id: string;
   };
 };
+
 // this API resource may actually be less sparse than
 // the interface suggests, but Jira REST can be unreliable
 export type JiraWorkLog = Partial<{
@@ -72,27 +73,25 @@ export type JiraWorkLog = Partial<{
   }>;
 }>;
 
+export type JiraWorkLogResponse = {
+  startAt: number;
+  maxResults: number;
+  total: number;
+  worklogs: Array<JiraWorkLog>;
+};
+
 export interface JiraIssue {
   key: string;
-  fields: Partial<{
-    worklog: Partial<{
-      worklogs: Array<JiraWorkLog>;
-    }>;
-  }>;
 }
 
 export interface BaseIterable {
   timeEntry: HarvestTimeEntry;
+  config: Config;
 }
 
-export type WithFullConfig = BaseIterable & {
-  config: Config;
-};
-
 export type ProjectConfigEnrichment = { projectConfig: ProjectConfig };
-export type WithProjectConfig = WithFullConfig &
-  Partial<ProjectConfigEnrichment>;
-export type DefinitelyWithProjectConfig = WithFullConfig &
+export type WithProjectConfig = BaseIterable & Partial<ProjectConfigEnrichment>;
+export type DefinitelyWithProjectConfig = BaseIterable &
   ProjectConfigEnrichment;
 
 export type UserTzEnrichment = { userTz: string };
@@ -103,3 +102,7 @@ export type JiraIssueEnrichment = { jiraIssue: JiraIssue };
 export type WithJiraIssue = DefinitelyWithUserTz & Partial<JiraIssueEnrichment>;
 export type DefinitelyWithJiraIssue = DefinitelyWithUserTz &
   JiraIssueEnrichment;
+
+export type WorkLogEnrichment = { workLogs: Array<JiraWorkLog> };
+export type DefinitelyWithWorkLogs = DefinitelyWithJiraIssue &
+  WorkLogEnrichment;


### PR DESCRIPTION
### The Problem
The way that we currently avoid creating duplicate worklogs in Jira for a given Harvest time entry is pretty janky: rather than using a sqlite db or something like that to ensure we only log things once, we just use the worklog comment to track the corresponding record in Harvest. This isn't great, but it's also worked well enough _thus far_. Unfortunately, however, I've noticed that when logging time to a Jira ticket with a large amount of worklogs attached, `harvest-to-jira` pretty consistently wants to double-log time entries. This is because the API's [issue resource](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-get) does not actually return all of the worklog records associated with a particular Jira issue; in order to get every worklog record, you must actually use the [issue worklogs resource](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-worklogs/#api-rest-api-3-issue-issueidorkey-worklog-get). 

### The Solution
This PR adds a new step to `harvest-to-jira` pipeline called `enrichWithWorkLogs`, which fetches _all_ of the worklogs attached to a given time entry's Jira issue. When determining if a Harvest time entry can be logged to Jira, the tool checks every single worklog record. Is this kinda dumb and inefficient? Yes! But IMO it's the best option until I've implemented a robust anti-duplication logic.