### PR TITLE
Silas found a bug

### DIFF
--- a/util.ts
+++ b/util.ts
@@ -75,9 +75,12 @@ const getHarvestTimeEntries = async function* (
       per_page: 100,
       from: timeFloor.toString(),
       to: timeCeiling.toString(),
+      user: config.user.harvestUserId,
     };
     Object.entries(params).forEach(([key, value]) => {
-      url.searchParams.set(key, value.toString());
+      if (value) {
+        url.searchParams.set(key, value.toString());
+      }
     });
     const response = await fetch(url.toString(), {
       method: "GET",

--- a/util.ts
+++ b/util.ts
@@ -75,7 +75,7 @@ const getHarvestTimeEntries = async function* (
       per_page: 100,
       from: timeFloor.toString(),
       to: timeCeiling.toString(),
-      user: config.user.harvestUserId,
+      user_id: config.user.harvestUserId,
     };
     Object.entries(params).forEach(([key, value]) => {
       if (value) {


### PR DESCRIPTION
If you're a harvest admin, `GET /v2/time_entries` returns _all_ users time entries. This change fetches only the time entries for the configured user.